### PR TITLE
2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Use of this software is subject to the terms and conditions of the license agree
 
  
 ---
-Copyright (C) 2012-2021, Tealium Inc.
+Copyright (C) 2012-2022, Tealium Inc.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.tealium.example"
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,17 +27,17 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.tealium:kotlin-core:1.4.0'
+    implementation 'com.tealium:kotlin-core:1.5.1'
     implementation 'com.tealium:kotlin-lifecycle:1.1.1'
-    implementation 'com.tealium:kotlin-tagmanagement-dispatcher:1.1.2'
-    implementation 'com.tealium:kotlin-remotecommand-dispatcher:1.1.1'
+    implementation 'com.tealium:kotlin-tagmanagement-dispatcher:1.2.0'
+    implementation 'com.tealium:kotlin-remotecommand-dispatcher:1.2.1'
     releaseImplementation "com.tealium.remotecommands:braze:$tealium_braze_version"
     debugImplementation project(path: ':braze')
 
-    implementation 'com.appboy:android-sdk-ui:19.0.0'
+    implementation "com.appboy:android-sdk-ui:$braze_version"
 
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.12'
     implementation "androidx.core:core-ktx:+"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/braze/build.gradle
+++ b/braze/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 32
+        targetSdkVersion 33
 
         buildConfigField 'String', 'TEALIUM_BRAZE_VERSION', "\"$tealium_braze_version\""
 

--- a/braze/build.gradle
+++ b/braze/build.gradle
@@ -25,20 +25,6 @@ android {
         }
     }
 
-    sourceSets {
-        release {
-            manifest.srcFile 'src/main/AndroidManifest.xml'
-        }
-
-        debug {
-            manifest.srcFile 'src/androidTest/AndroidManifest.xml'
-        }
-
-        main {
-            manifest.srcFile 'src/main/AndroidManifest.xml'
-        }
-    }
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -48,7 +34,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     api 'com.tealium:remotecommands:1.0.1'
-    api 'com.appboy:android-sdk-ui:[15.0,20.0)'
+    api "com.appboy:android-sdk-ui:$braze_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
     androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/braze/src/androidTest/AndroidManifest.xml
+++ b/braze/src/androidTest/AndroidManifest.xml
@@ -8,7 +8,7 @@
                 <!--<category android:name="${applicationId}" />-->
             <!--</intent-filter>-->
         <!--</receiver>-->
-        <activity android:name=".QAActivity" />
+<!--        <activity android:name=".QAActivity" />-->
 
     </application>
 

--- a/braze/src/androidTest/java/com/tealium/remotecommands/braze/BrazeRemoteCommandTests.java
+++ b/braze/src/androidTest/java/com/tealium/remotecommands/braze/BrazeRemoteCommandTests.java
@@ -1,17 +1,22 @@
 package com.tealium.remotecommands.braze;
 
+import android.app.Activity;
+import android.app.Application;
+import android.os.Looper;
+
 import androidx.annotation.NonNull;
-import androidx.test.rule.ActivityTestRule;
+import androidx.annotation.Nullable;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.runner.AndroidJUnit4;
 
-import com.appboy.Appboy;
+import com.braze.Braze;
 import com.braze.configuration.BrazeConfig;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.junit.runner.RunWith;
@@ -30,13 +35,20 @@ public class BrazeRemoteCommandTests {
         super();
     }
 
-    @Rule
-    public ActivityTestRule<QAActivity> QAActivity = new ActivityTestRule<>(com.tealium.remotecommands.braze.QAActivity.class);
+    public Application context = ApplicationProvider.getApplicationContext();
+    public Activity activity;
+
+    @BeforeClass
+    public static void setupClass() {
+        Looper.prepare();
+    }
 
     @Before
     public void setup() {
-        Appboy.enableSdk(QAActivity.getActivity().getApplication().getApplicationContext());
-        Appboy.enableMockAppboyNetworkRequestsAndDropEventsMode();
+        activity = new QAActivity();
+
+        Braze.enableSdk(context.getApplicationContext());
+        Braze.enableMockNetworkRequestsAndDropEventsMode();
 
         brazeRemoteCommand = newMockRemoteCommand();
     }
@@ -47,7 +59,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.INITIALIZE);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(context, activity) {
                 @Override
                 public void initialize(String apiKey, JSONObject launchOptions) {
                     Assert.assertEquals("apiKey does not match.", TestData.Values.API_KEY, apiKey);
@@ -74,7 +86,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.INITIALIZE);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
                 public void initialize(@NonNull String apiKey, JSONObject launchOptions, List<BrazeRemoteCommand.ConfigOverrider> overrides) {
                     Assert.assertEquals("apiKey does not match.", TestData.Values.API_KEY, apiKey);
@@ -102,7 +114,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.INITIALIZE);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 // all settings are verified in an override created by setupInitTestWithAllSettings(..)
             };
             brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
@@ -123,7 +135,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.LOG_CUSTOM_EVENT);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
                 public void logCustomEvent(@NonNull String eventName, JSONObject eventProperties) {
                     Assert.assertEquals("eventName parameter does not match what was sent", TestData.Values.EVENT_NAME, eventName);
@@ -148,7 +160,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.LOG_CUSTOM_EVENT);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
                 public void logCustomEvent(@NonNull String eventName, JSONObject eventProperties) {
                     Assert.assertEquals("eventName parameter does not match what was sent", TestData.Values.EVENT_NAME, eventName);
@@ -173,7 +185,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.LOG_CUSTOM_EVENT);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
                 public void logCustomEvent(@NonNull String eventName, JSONObject eventProperties) {
                     Assert.assertEquals("eventName parameter does not match what was sent", TestData.Values.EVENT_NAME, eventName);
@@ -198,7 +210,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.LOG_PURCHASE);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
                 public void logPurchase(@NonNull String productId, String currency, @NonNull BigDecimal unitPrice, Integer quantity, JSONObject purchaseProerties) {
                     Assert.assertEquals("productId does not match what was sent.", TestData.Values.PRODUCT_ID, productId);
@@ -227,7 +239,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.LOG_PURCHASE);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
                 public void logPurchase(@NonNull String productId, String currency, @NonNull BigDecimal unitPrice, Integer quantity, JSONObject purchaseProerties) {
                     Assert.assertEquals("productId does not match what was sent.", TestData.Values.PRODUCT_ID, productId);
@@ -255,7 +267,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.LOG_PURCHASE);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
                 public void logPurchase(@NonNull String productId, String currency, @NonNull BigDecimal unitPrice, Integer quantity, JSONObject purchaseProerties) {
                     Assert.assertEquals("productId does not match what was sent.", TestData.Values.PRODUCT_ID, productId);
@@ -283,7 +295,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.WIPE_DATA);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
                 public void wipeData() {
                     // nothing to test here - just need to verify it's been called
@@ -304,14 +316,13 @@ public class BrazeRemoteCommandTests {
     @Test
     public void testDisableSdk() {
         Collection<String> expectedMethods = new ArrayList<>();
-        expectedMethods.add(TestData.Methods.ENABLE_SDK);
+        expectedMethods.add(TestData.Methods.DISABLE_SDK);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
-                public void enableSdk(Boolean enabled) {
-                    Assert.assertFalse("enabled should be false", enabled);
-                    super.enableSdk(enabled);
+                public void disableSdk() {
+                    super.disableSdk();
                 }
             };
             brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
@@ -331,11 +342,10 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.ENABLE_SDK);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
-                public void enableSdk(Boolean enabled) {
-                    Assert.assertTrue("enabled should be true", enabled);
-                    super.enableSdk(enabled);
+                public void enableSdk() {
+                    super.enableSdk();
                 }
             };
             brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
@@ -355,7 +365,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.SET_USER_ALIAS);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
                 public void setUserAlias(String userAlias, String aliasLabel) {
                     Assert.assertEquals("userAlias does not match what was sent", TestData.Values.USER_ALIAS, userAlias);
@@ -380,16 +390,41 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.SET_USER_ID);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
-                public void setUserId(String userId) {
+                public void setUserId(String userId, @Nullable String sdkAuthSignature) {
                     Assert.assertEquals("userId does not match what was sent", TestData.Values.USER_ID, userId);
-                    super.setUserId(userId);
+                    super.setUserId(userId, sdkAuthSignature);
                 }
             };
             brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
 
             brazeRemoteCommand.onInvoke(TestData.Responses.userId());
+            TestUtils.assertContainsAllAndOnly(mockBrazeInstance.methodsCalled, expectedMethods);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testUserId_WithAuthSignature() {
+        Collection<String> expectedMethods = new ArrayList<>();
+        expectedMethods.add(TestData.Methods.SET_USER_ID);
+
+        try {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
+                @Override
+                public void setUserId(String userId, @Nullable String sdkAuthSignature) {
+                    Assert.assertEquals("userId does not match what was sent", TestData.Values.USER_ID, userId);
+                    Assert.assertEquals("sdkAuthSignature does not match what was sent", TestData.Values.SDK_AUTH_SIGNATURE, sdkAuthSignature);
+                    super.setUserId(userId, sdkAuthSignature);
+                }
+            };
+            brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
+
+            brazeRemoteCommand.onInvoke(TestData.Responses.userIdWithAuthSignature());
             TestUtils.assertContainsAllAndOnly(mockBrazeInstance.methodsCalled, expectedMethods);
 
         } catch (Exception e) {
@@ -410,13 +445,17 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.SET_HOME_CITY);
         expectedMethods.add(TestData.Methods.SET_GENDER);
         expectedMethods.add(TestData.Methods.SET_LANGUAGE);
+        expectedMethods.add(TestData.Methods.SET_COUNTRY);
+        expectedMethods.add(TestData.Methods.SET_PHONE);
+        expectedMethods.add(TestData.Methods.SET_DATE_OF_BIRTH);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
-                public void setUserId(String userId) {
+                public void setUserId(String userId, @Nullable String sdkAuthSignature) {
                     Assert.assertEquals("userId does not match what was sent", TestData.Values.USER_ID, userId);
-                    super.setUserId(userId);
+                    Assert.assertEquals("sdkAuthSignature does not match what was sent", TestData.Values.SDK_AUTH_SIGNATURE, sdkAuthSignature);
+                    super.setUserId(userId, sdkAuthSignature);
                 }
 
                 @Override
@@ -461,6 +500,23 @@ public class BrazeRemoteCommandTests {
                     Assert.assertEquals("language does not match what was sent", TestData.Values.USER_LANGUAGE, language);
                     super.setUserLanguage(language);
                 }
+
+                @Override
+                public void setUserCountry(String country) {
+                    Assert.assertEquals("country does not match what was sent", TestData.Values.USER_COUNTRY, country);
+                    super.setUserCountry(country);
+                }
+
+                @Override
+                public void setUserPhone(String phone) {
+                    Assert.assertEquals("phone does not match what was sent", TestData.Values.USER_PHONE, phone);
+                    super.setUserPhone(phone);
+                }
+
+                @Override
+                public void setUserDateOfBirth(String dob) {
+                    super.setUserDateOfBirth(dob);
+                }
             };
             brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
 
@@ -485,7 +541,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.INCREMENT_USER_CUSTOM_ATTRIBUTE);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
                 public void setUserCustomAttributeArray(String key, String[] attributeArray) {
                     JSONArray jsonArray = new JSONArray();
@@ -520,7 +576,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.REMOVE_USER_CUSTOM_ATTRIBUTE_ARRAY);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
                 @Override
                 public void setUserCustomAttributeArray(String key, String[] attributeArray) {
                     JSONArray jsonArray = new JSONArray();
@@ -544,56 +600,16 @@ public class BrazeRemoteCommandTests {
     }
 
     @Test
-    public void testSocialData() {
-        Collection<String> expectedMethods = new ArrayList<>();
-        expectedMethods.add(TestData.Methods.INITIALIZE);
-        expectedMethods.add(TestData.Methods.SET_FACEBOOK_DATA);
-        expectedMethods.add(TestData.Methods.SET_TWITTER_DATA);
-
-        try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
-            };
-            brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
-
-            brazeRemoteCommand.onInvoke(TestData.Responses.socialData());
-            TestUtils.assertContainsAllAndOnly(mockBrazeInstance.methodsCalled, expectedMethods);
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail();
-        }
-    }
-
-    @Test
     public void testRequestFlush() {
         Collection<String> expectedMethods = new ArrayList<>();
         expectedMethods.add(TestData.Methods.REQUEST_FLUSH);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
             };
             brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
 
             brazeRemoteCommand.onInvoke(TestData.Responses.requestFlush());
-            TestUtils.assertContainsAllAndOnly(mockBrazeInstance.methodsCalled, expectedMethods);
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail();
-        }
-    }
-
-    @Test
-    public void testRegisterPush() {
-        Collection<String> expectedMethods = new ArrayList<>();
-        expectedMethods.add(TestData.Methods.REGISTER_PUSH);
-
-        try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
-            };
-            brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
-
-            brazeRemoteCommand.onInvoke(TestData.Responses.registerPush());
             TestUtils.assertContainsAllAndOnly(mockBrazeInstance.methodsCalled, expectedMethods);
 
         } catch (Exception e) {
@@ -608,7 +624,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.ADD_TO_SUBSCRIPTION);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
             };
             brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
 
@@ -627,7 +643,7 @@ public class BrazeRemoteCommandTests {
         expectedMethods.add(TestData.Methods.REMOVE_FROM_SUBSCRIPTION);
 
         try {
-            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity()) {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
             };
             brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
 
@@ -640,12 +656,142 @@ public class BrazeRemoteCommandTests {
         }
     }
 
+    @Test
+    public void testSetSdkAuthSignature() {
+        Collection<String> expectedMethods = new ArrayList<>();
+        expectedMethods.add(TestData.Methods.SET_SDK_AUTH_SIGNATURE);
+
+        try {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
+                @Override
+                public void setSdkAuthSignature(String signature) {
+                    Assert.assertEquals("signature does not match what was sent", TestData.Values.SDK_AUTH_SIGNATURE, signature);
+                    super.setSdkAuthSignature(signature);
+                }
+            };
+            brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
+
+            brazeRemoteCommand.onInvoke(TestData.Responses.setSdkAuthSignature());
+            TestUtils.assertContainsAllAndOnly(mockBrazeInstance.methodsCalled, expectedMethods);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testSetLastLocation_RequiredParams() {
+        Collection<String> expectedMethods = new ArrayList<>();
+        expectedMethods.add(TestData.Methods.SET_LAST_KNOWN_LOCATION);
+
+        try {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
+                @Override
+                public void setLastKnownLocation(@NonNull Double latitude, @NonNull Double longitude, @Nullable Double altitude, @Nullable Double accuracy) {
+                    Assert.assertEquals("latitude does not match what was sent", TestData.Values.LATITUDE, latitude, 0.0);
+                    Assert.assertEquals("longitude does not match what was sent", TestData.Values.LONGITUDE, longitude, 0.0);
+                    Assert.assertNull(altitude);
+                    Assert.assertNull(accuracy);
+                    super.setLastKnownLocation(latitude, longitude, altitude, accuracy);
+                }
+            };
+            brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
+
+            brazeRemoteCommand.onInvoke(TestData.Responses.setLastKnownLocation_RequiredValues());
+            TestUtils.assertContainsAllAndOnly(mockBrazeInstance.methodsCalled, expectedMethods);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testSetLastLocation_AllParams() {
+        Collection<String> expectedMethods = new ArrayList<>();
+        expectedMethods.add(TestData.Methods.SET_LAST_KNOWN_LOCATION);
+
+        try {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
+                @Override
+                public void setLastKnownLocation(@NonNull Double latitude, @NonNull Double longitude, @Nullable Double altitude, @Nullable Double accuracy) {
+                    Assert.assertEquals("latitude does not match what was sent", TestData.Values.LATITUDE, latitude, 0.0);
+                    Assert.assertEquals("longitude does not match what was sent", TestData.Values.LONGITUDE, longitude, 0.0);
+
+                    Assert.assertEquals("altitude does not match what was sent", TestData.Values.ALTITUDE, altitude, 0.0);
+                    Assert.assertEquals("accuracy does not match what was sent", TestData.Values.ACCURACY, accuracy, 0.0);
+                    super.setLastKnownLocation(latitude, longitude, altitude, accuracy);
+                }
+            };
+            brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
+
+            brazeRemoteCommand.onInvoke(TestData.Responses.setLastKnownLocation_AllValues());
+            TestUtils.assertContainsAllAndOnly(mockBrazeInstance.methodsCalled, expectedMethods);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testSetAdTrackingEnabled() {
+        Collection<String> expectedMethods = new ArrayList<>();
+        expectedMethods.add(TestData.Methods.SET_AD_TRACKING_ENABLED);
+
+        try {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
+                @Override
+                public void setAdTrackingEnabled(String googleAdid, boolean limitAdTracking) {
+                    Assert.assertEquals("googleAdid does not match what was sent", TestData.Values.GOOGLE_ADID, googleAdid);
+                    Assert.assertEquals("limitAdTracking does not match what was sent", TestData.Values.AD_TRACKING_ENABLED, !limitAdTracking);
+
+                    super.setAdTrackingEnabled(googleAdid, limitAdTracking);
+                }
+            };
+            brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
+
+            brazeRemoteCommand.onInvoke(TestData.Responses.setAdTrackingEnabled());
+            TestUtils.assertContainsAllAndOnly(mockBrazeInstance.methodsCalled, expectedMethods);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testSetAdTrackingEnabled_MissingAdid() {
+        Collection<String> expectedMethods = new ArrayList<>();
+        // no expected methods; method not called if `google_adid` not present
+
+        try {
+            MockBrazeInstance mockBrazeInstance = new MockBrazeInstance((Application) context, activity) {
+                @Override
+                public void setAdTrackingEnabled(String googleAdid, boolean limitAdTracking) {
+                    if (googleAdid == null) Assert.fail(); // google adid is required
+
+                    super.setAdTrackingEnabled(googleAdid, limitAdTracking);
+                }
+            };
+            brazeRemoteCommand.setBrazeCommand(mockBrazeInstance);
+
+            brazeRemoteCommand.onInvoke(TestData.Responses.setAdTrackingEnabled_MissingAdid());
+            TestUtils.assertContainsAllAndOnly(mockBrazeInstance.methodsCalled, expectedMethods);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
     public MockBrazeRemoteCommand newMockRemoteCommand() {
-        return new MockBrazeRemoteCommand(QAActivity.getActivity().getApplication(), false, null, false, null);
+        return new MockBrazeRemoteCommand((Application) context, false, null, false, null);
     }
 
     public MockBrazeInstance newMockBrazeInstance() {
-        return new MockBrazeInstance(QAActivity.getActivity().getApplication(), QAActivity.getActivity());
+        return new MockBrazeInstance((Application) context, activity);
     }
 
     public void setupInitTestWithApiKey(BrazeRemoteCommand brc) {

--- a/braze/src/androidTest/java/com/tealium/remotecommands/braze/BrazeUtilityMethodTests.java
+++ b/braze/src/androidTest/java/com/tealium/remotecommands/braze/BrazeUtilityMethodTests.java
@@ -3,6 +3,7 @@ package com.tealium.remotecommands.braze;
 import androidx.test.runner.AndroidJUnit4;
 
 import com.appboy.enums.Gender;
+import com.appboy.enums.Month;
 import com.braze.models.outgoing.BrazeProperties;
 
 import org.junit.Assert;
@@ -14,6 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
+import java.util.Date;
 
 @RunWith(AndroidJUnit4.class)
 public class BrazeUtilityMethodTests {
@@ -48,6 +50,52 @@ public class BrazeUtilityMethodTests {
 
         // default
         Assert.assertNull(BrazeUtils.getGenderEnumFromString("UNEXPECTED VALUE"));
+    }
+
+    @Test
+    public void monthEnumFromIntTests() {
+        Assert.assertEquals(Month.JANUARY, BrazeUtils.getMonthEnumFromInt(0));
+        Assert.assertEquals(Month.FEBRUARY, BrazeUtils.getMonthEnumFromInt(1));
+        Assert.assertEquals(Month.MARCH, BrazeUtils.getMonthEnumFromInt(2));
+        Assert.assertEquals(Month.APRIL, BrazeUtils.getMonthEnumFromInt(3));
+        Assert.assertEquals(Month.MAY, BrazeUtils.getMonthEnumFromInt(4));
+        Assert.assertEquals(Month.JUNE, BrazeUtils.getMonthEnumFromInt(5));
+        Assert.assertEquals(Month.JULY, BrazeUtils.getMonthEnumFromInt(6));
+        Assert.assertEquals(Month.AUGUST, BrazeUtils.getMonthEnumFromInt(7));
+        Assert.assertEquals(Month.SEPTEMBER, BrazeUtils.getMonthEnumFromInt(8));
+        Assert.assertEquals(Month.OCTOBER, BrazeUtils.getMonthEnumFromInt(9));
+        Assert.assertEquals(Month.NOVEMBER, BrazeUtils.getMonthEnumFromInt(10));
+        Assert.assertEquals(Month.DECEMBER, BrazeUtils.getMonthEnumFromInt(11));
+
+        Assert.assertNull(BrazeUtils.getMonthEnumFromInt(-1));
+        Assert.assertNull(BrazeUtils.getMonthEnumFromInt(12));
+    }
+
+    @Test
+    public void parseDateTest_SimpleDateFormat() {
+        Date date = BrazeUtils.parseDate(TestData.Values.DOB_ISO_8601);
+
+        Assert.assertEquals(1, date.getDate());
+        Assert.assertEquals(0, date.getMonth());
+        Assert.assertEquals(2000 - 1900, date.getYear());
+    }
+
+    @Test
+    public void parseDateTest_BrazeShort() {
+        Date date = BrazeUtils.parseDate(TestData.Values.DOB_BRAZE_SHORT);
+
+        Assert.assertEquals(1, date.getDate());
+        Assert.assertEquals(0, date.getMonth());
+        Assert.assertEquals(2000 - 1900, date.getYear());
+    }
+
+    @Test
+    public void parseDateTest_BrazeLong() {
+        Date date = BrazeUtils.parseDate(TestData.Values.DOB_BRAZE_LONG);
+
+        Assert.assertEquals(1, date.getDate());
+        Assert.assertEquals(0, date.getMonth());
+        Assert.assertEquals(2000 - 1900, date.getYear());
     }
 
     @Test

--- a/braze/src/androidTest/java/com/tealium/remotecommands/braze/MockBrazeInstance.java
+++ b/braze/src/androidTest/java/com/tealium/remotecommands/braze/MockBrazeInstance.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -41,8 +42,14 @@ public class MockBrazeInstance extends BrazeInstance {
     }
 
     @Override
-    public void enableSdk(Boolean enabled) {
-        super.enableSdk(enabled);
+    public void enableSdk() {
+        super.enableSdk();
+        addCallerName();
+    }
+
+    @Override
+    public void disableSdk() {
+        super.disableSdk();
         addCallerName();
     }
 
@@ -53,8 +60,8 @@ public class MockBrazeInstance extends BrazeInstance {
     }
 
     @Override
-    public void setUserId(String userId) {
-        super.setUserId(userId);
+    public void setUserId(String userId, @Nullable String sdkAuthSignature) {
+        super.setUserId(userId, sdkAuthSignature);
         addCallerName();
     }
 
@@ -221,18 +228,6 @@ public class MockBrazeInstance extends BrazeInstance {
     }
 
     @Override
-    public void setFacebookData(String facebookId, String firstName, String lastName, String email, String bio, String cityName, String gender, Integer numberOfFriends, JSONArray listOfLikes, String birthday) {
-        super.setFacebookData(facebookId, firstName, lastName, email, bio, cityName, gender, numberOfFriends, listOfLikes, birthday);
-        addCallerName();
-    }
-
-    @Override
-    public void setTwitterData(Integer twitterUserId, String twitterHandle, String name, String description, Integer followerCount, Integer followingCount, Integer tweetCount, String profileImageUrl) {
-        super.setTwitterData(twitterUserId, twitterHandle, name, description, followerCount, followingCount, tweetCount, profileImageUrl);
-        addCallerName();
-    }
-
-    @Override
     public void logCustomEvent(@NonNull String eventName) {
         super.logCustomEvent(eventName);
         addCallerName();
@@ -275,12 +270,6 @@ public class MockBrazeInstance extends BrazeInstance {
     }
 
     @Override
-    public void registerToken(String token) {
-        super.registerToken(token);
-        addCallerName();
-    }
-
-    @Override
     public void addToSubscriptionGroup(String groupId) {
         super.addToSubscriptionGroup(groupId);
         addCallerName();
@@ -289,6 +278,42 @@ public class MockBrazeInstance extends BrazeInstance {
     @Override
     public void removeFromSubscriptionGroup(String groupId) {
         super.removeFromSubscriptionGroup(groupId);
+        addCallerName();
+    }
+
+    @Override
+    public void setUserCountry(String country) {
+        super.setUserCountry(country);
+        addCallerName();
+    }
+
+    @Override
+    public void setUserPhone(String phone) {
+        super.setUserPhone(phone);
+        addCallerName();
+    }
+
+    @Override
+    public void setUserDateOfBirth(String dob) {
+        super.setUserDateOfBirth(dob);
+        addCallerName();
+    }
+
+    @Override
+    public void setLastKnownLocation(@NonNull Double latitude, @NonNull Double longitude, @Nullable Double altitude, @Nullable Double accuracy) {
+        super.setLastKnownLocation(latitude, longitude, altitude, accuracy);
+        addCallerName();
+    }
+
+    @Override
+    public void setSdkAuthSignature(String signature) {
+        super.setSdkAuthSignature(signature);
+        addCallerName();
+    }
+
+    @Override
+    public void setAdTrackingEnabled(String googleAdid, boolean limitAdTracking) {
+        super.setAdTrackingEnabled(googleAdid, limitAdTracking);
         addCallerName();
     }
 }

--- a/braze/src/androidTest/java/com/tealium/remotecommands/braze/MockBrazeRemoteCommand.java
+++ b/braze/src/androidTest/java/com/tealium/remotecommands/braze/MockBrazeRemoteCommand.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletableFuture;
 public class MockBrazeRemoteCommand extends BrazeRemoteCommand {
 
     public CompletableFuture<Boolean> future = new CompletableFuture<>();
-    private List<Validator> validators = new ArrayList<>();
+    private final List<Validator> validators = new ArrayList<>();
 
     public MockBrazeRemoteCommand(Application app) {
         super(app);

--- a/braze/src/androidTest/java/com/tealium/remotecommands/braze/TestData.java
+++ b/braze/src/androidTest/java/com/tealium/remotecommands/braze/TestData.java
@@ -8,12 +8,10 @@ import org.json.JSONObject;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 
 import static com.tealium.remotecommands.braze.BrazeConstants.SEPARATOR;
@@ -22,6 +20,7 @@ import static com.tealium.remotecommands.braze.BrazeConstants.Config;
 import static com.tealium.remotecommands.braze.BrazeConstants.User;
 import static com.tealium.remotecommands.braze.BrazeConstants.Event;
 import static com.tealium.remotecommands.braze.BrazeConstants.Purchase;
+import static com.tealium.remotecommands.braze.BrazeConstants.Location;
 
 public final class TestData {
 
@@ -58,7 +57,6 @@ public final class TestData {
             payload.put(Config.ENABLE_NEWS_FEED_INDICATOR, Values.ENABLE_NEWS_FEED_INDICATOR);
             payload.put(Config.LARGE_NOTIFICATION_ICON, Values.LARGE_NOTIFICATION_ICON);
             payload.put(Config.SMALL_NOTIFICATION_ICON, Values.SMALL_NOTIFICATION_ICON);
-            payload.put(Config.LOCALE_MAPPING, Values.LOCALE_MAPPING);
             payload.put(Config.SESSION_TIMEOUT, Values.SESSION_TIMEOUT);
             payload.put(Config.TRIGGER_INTERVAL_SECONDS, Values.TRIGGER_INTERVAL_SECONDS);
 
@@ -75,15 +73,13 @@ public final class TestData {
         public static Map<String, Object> enableSdk() {
             Map<String, Object> payload = new HashMap<>();
             payload.put(Commands.COMMAND_KEY, Commands.ENABLE_SDK);
-            payload.put(Config.ENABLE_SDK, true);
 
             return payload;
         }
 
         public static Map<String, Object> disableSdk() {
             Map<String, Object> payload = new HashMap<>();
-            payload.put(Commands.COMMAND_KEY, Commands.ENABLE_SDK);
-            payload.put(Config.ENABLE_SDK, false);
+            payload.put(Commands.COMMAND_KEY, Commands.DISABLE_SDK);
 
             return payload;
         }
@@ -245,32 +241,6 @@ public final class TestData {
 
             return payload;
         }
-
-        public static Map<String, Object> socialData() {
-            Map<String, Object> payload = new HashMap<>();
-
-            payload.put(Commands.COMMAND_KEY, String.join(SEPARATOR,
-                    Commands.INITIALIZE,
-                    Commands.FACEBOOK_USER,
-                    Commands.TWITTER_USER
-            ));
-            payload.put(Config.API_KEY, Values.API_KEY);
-
-            payload.put(User.FACEBOOK_ID, Values.FACEBOOK_ID);
-            payload.put(User.FIRST_NAME, Values.USER_FIRST_NAME);
-            payload.put(User.EMAIL, Values.USER_EMAIL);
-            payload.put(User.LAST_NAME, Values.USER_LAST_NAME);
-            payload.put(User.DESCRIPTION, Values.USER_DESCRIPTION);
-            payload.put(User.HOME_CITY, Values.USER_HOME_CITY);
-            payload.put(User.TWITTER_NAME, Values.TWITTER_HANDLE);
-            payload.put(User.SCREEN_NAME, Values.SCREEN_NAME);
-            payload.put(User.TWITTER_ID, Values.TWITTER_ID);
-            payload.put(User.GENDER, Values.USER_GENDER);
-            payload.put(User.FRIENDS_COUNT, Values.FRIENDSCOUNT);
-            payload.put(User.FOLLOWERS_COUNT, Values.FOLLOWERS_COUNT);
-
-            return payload;
-        }
     }
 
     public static final class Responses {
@@ -318,7 +288,6 @@ public final class TestData {
             payload.put(Config.ENABLE_NEWS_FEED_INDICATOR, Values.ENABLE_NEWS_FEED_INDICATOR);
             payload.put(Config.LARGE_NOTIFICATION_ICON, Values.LARGE_NOTIFICATION_ICON);
             payload.put(Config.SMALL_NOTIFICATION_ICON, Values.SMALL_NOTIFICATION_ICON);
-            payload.put(Config.LOCALE_MAPPING, Values.LOCALE_MAPPING);
             payload.put(Config.SESSION_TIMEOUT, Values.SESSION_TIMEOUT);
             payload.put(Config.TRIGGER_INTERVAL_SECONDS, Values.TRIGGER_INTERVAL_SECONDS);
 
@@ -335,15 +304,13 @@ public final class TestData {
         public static RemoteCommand.Response enableSdk() throws JSONException {
             JSONObject payload = new JSONObject();
             payload.put(Commands.COMMAND_KEY, Commands.ENABLE_SDK);
-            payload.put(Config.ENABLE_SDK, true);
 
             return create(payload);
         }
 
         public static RemoteCommand.Response disableSdk() throws JSONException {
             JSONObject payload = new JSONObject();
-            payload.put(Commands.COMMAND_KEY, Commands.ENABLE_SDK);
-            payload.put(Config.ENABLE_SDK, false);
+            payload.put(Commands.COMMAND_KEY, Commands.DISABLE_SDK);
 
             return create(payload);
         }
@@ -427,6 +394,15 @@ public final class TestData {
             return create(payload);
         }
 
+        public static RemoteCommand.Response userIdWithAuthSignature() throws JSONException {
+            JSONObject payload = new JSONObject();
+            payload.put(Commands.COMMAND_KEY, Commands.USER_IDENTIFIER);
+            payload.put(User.USER_ID, Values.USER_ID);
+            payload.put(User.SDK_AUTH_SIGNATURE, Values.SDK_AUTH_SIGNATURE);
+
+            return create(payload);
+        }
+
         public static RemoteCommand.Response userAllAttributes() throws JSONException {
             JSONObject payload = new JSONObject();
             Collection<String> commandList = new LinkedList<>();
@@ -442,6 +418,7 @@ public final class TestData {
             payload.put(User.USER_ID, Values.USER_ID);
             payload.put(User.ALIAS, Values.USER_ALIAS);
             payload.put(User.ALIAS_LABEL, Values.USER_ALIAS_LABEL);
+            payload.put(User.SDK_AUTH_SIGNATURE, Values.SDK_AUTH_SIGNATURE);
 
             payload.put(User.FIRST_NAME, Values.USER_FIRST_NAME);
             payload.put(User.LAST_NAME, Values.USER_LAST_NAME);
@@ -449,6 +426,9 @@ public final class TestData {
             payload.put(User.GENDER, Values.USER_GENDER);
             payload.put(User.LANGUAGE, Values.USER_LANGUAGE);
             payload.put(User.HOME_CITY, Values.USER_HOME_CITY);
+            payload.put(User.COUNTRY, Values.USER_COUNTRY);
+            payload.put(User.PHONE, Values.USER_PHONE);
+            payload.put(User.DATE_OF_BIRTH, Values.DOB_BRAZE_SHORT);
 
             return create(payload);
         }
@@ -489,49 +469,12 @@ public final class TestData {
             return create(payload);
         }
 
-        public static RemoteCommand.Response socialData() throws JSONException {
-            JSONObject payload = new JSONObject();
-            Collection<String> commandList = new LinkedList<>();
-            commandList.add(Commands.INITIALIZE);
-            commandList.add(Commands.FACEBOOK_USER);
-            commandList.add(Commands.TWITTER_USER);
-
-            payload.put(Commands.COMMAND_KEY, String.join(SEPARATOR, commandList));
-            payload.put(Config.API_KEY, Values.API_KEY);
-
-            payload.put(User.FACEBOOK_ID, Values.FACEBOOK_ID);
-            payload.put(User.FIRST_NAME, Values.USER_FIRST_NAME);
-            payload.put(User.EMAIL, Values.USER_EMAIL);
-            payload.put(User.LAST_NAME, Values.USER_LAST_NAME);
-            payload.put(User.DESCRIPTION, Values.USER_DESCRIPTION);
-            payload.put(User.HOME_CITY, Values.USER_HOME_CITY);
-            payload.put(User.TWITTER_NAME, Values.TWITTER_HANDLE);
-            payload.put(User.SCREEN_NAME, Values.SCREEN_NAME);
-            payload.put(User.TWITTER_ID, Values.TWITTER_ID);
-            payload.put(User.GENDER, Values.USER_GENDER);
-            payload.put(User.FRIENDS_COUNT, Values.FRIENDSCOUNT);
-            payload.put(User.FOLLOWERS_COUNT, Values.FOLLOWERS_COUNT);
-
-            return create(payload);
-        }
-
         public static RemoteCommand.Response requestFlush() throws JSONException {
             JSONObject payload = new JSONObject();
             Collection<String> commandList = new LinkedList<>();
             commandList.add(Commands.FLUSH);
 
             payload.put(Commands.COMMAND_KEY, String.join(SEPARATOR, commandList));
-
-            return create(payload);
-        }
-
-        public static RemoteCommand.Response registerPush() throws JSONException {
-            JSONObject payload = new JSONObject();
-            Collection<String> commandList = new LinkedList<>();
-            commandList.add(Commands.REGISTER_TOKEN);
-
-            payload.put(Commands.COMMAND_KEY, String.join(SEPARATOR, commandList));
-            payload.put(User.PUSH_TOKEN, "12345");
 
             return create(payload);
         }
@@ -554,6 +497,66 @@ public final class TestData {
 
             payload.put(Commands.COMMAND_KEY, String.join(SEPARATOR, commandList));
             payload.put(User.SUBSCRIPTION_GROUP_ID, "12345");
+
+            return create(payload);
+        }
+
+        public static RemoteCommand.Response setLastKnownLocation_RequiredValues() throws JSONException {
+            JSONObject payload = new JSONObject();
+            Collection<String> commandList = new LinkedList<>();
+            commandList.add(Commands.SET_LAST_KNOWN_LOCATION);
+
+            payload.put(Commands.COMMAND_KEY, String.join(SEPARATOR, commandList));
+            payload.put(Location.LOCATION_LATITUDE, 0.0);
+            payload.put(Location.LOCATION_LONGITUDE, 1.1);
+
+            return create(payload);
+        }
+
+        public static RemoteCommand.Response setLastKnownLocation_AllValues() throws JSONException {
+            JSONObject payload = new JSONObject();
+            Collection<String> commandList = new LinkedList<>();
+            commandList.add(Commands.SET_LAST_KNOWN_LOCATION);
+
+            payload.put(Commands.COMMAND_KEY, String.join(SEPARATOR, commandList));
+            payload.put(Location.LOCATION_LATITUDE, 0.0);
+            payload.put(Location.LOCATION_LONGITUDE, 1.1);
+            payload.put(Location.LOCATION_ALTITUDE, 2.2);
+            payload.put(Location.LOCATION_ACCURACY, 3.3);
+
+            return create(payload);
+        }
+
+        public static RemoteCommand.Response setSdkAuthSignature() throws JSONException {
+            JSONObject payload = new JSONObject();
+            Collection<String> commandList = new LinkedList<>();
+            commandList.add(Commands.SET_SDK_AUTH_SIGNATURE);
+
+            payload.put(Commands.COMMAND_KEY, String.join(SEPARATOR, commandList));
+            payload.put(User.SDK_AUTH_SIGNATURE, Values.SDK_AUTH_SIGNATURE);
+
+            return create(payload);
+        }
+
+        public static RemoteCommand.Response setAdTrackingEnabled() throws JSONException {
+            JSONObject payload = new JSONObject();
+            Collection<String> commandList = new LinkedList<>();
+            commandList.add(Commands.SET_AD_TRACKING_ENABLED);
+
+            payload.put(Commands.COMMAND_KEY, String.join(SEPARATOR, commandList));
+            payload.put(User.GOOGLE_ADID, Values.GOOGLE_ADID);
+            payload.put(User.AD_TRACKING_ENABLED, Values.AD_TRACKING_ENABLED);
+
+            return create(payload);
+        }
+
+        public static RemoteCommand.Response setAdTrackingEnabled_MissingAdid() throws JSONException {
+            JSONObject payload = new JSONObject();
+            Collection<String> commandList = new LinkedList<>();
+            commandList.add(Commands.SET_AD_TRACKING_ENABLED);
+
+            payload.put(Commands.COMMAND_KEY, String.join(SEPARATOR, commandList));
+            payload.put(User.AD_TRACKING_ENABLED, Values.AD_TRACKING_ENABLED);
 
             return create(payload);
         }
@@ -580,10 +583,12 @@ public final class TestData {
         public static final Integer DEFAULT_NOTIFICATION_COLOR = 0xFF00FF;
         public static final Integer SESSION_TIMEOUT = 10;
         public static final Integer TRIGGER_INTERVAL_SECONDS = 10;
-        public static final List<String> LOCALE_MAPPING = new ArrayList<String>() {{
-            add("customLocale, customApiKeyForThatLocale");
-            add("fr_NC, anotherAPIKey");
-        }};
+        public static final String SDK_AUTH_SIGNATURE = "signature";
+        public static final String DOB_ISO_8601 = "2000-01-01T01:01:01Z";
+        public static final String DOB_BRAZE_SHORT = "2000-01-01";
+        public static final String DOB_BRAZE_LONG = "2000-01-01 01:01:01";
+        public static final String GOOGLE_ADID = "my_adid";
+        public static final boolean AD_TRACKING_ENABLED = false;
 
         // Events
         public static final String EVENT_NAME = "add_to_cart";
@@ -623,6 +628,8 @@ public final class TestData {
         public static final String USER_LANGUAGE = "english";
         public static final String USER_HOME_CITY = "Reading";
         public static final String USER_EMAIL = "email@test.com";
+        public static final String USER_PHONE = "++441234567890";
+        public static final String USER_COUNTRY = "USA";
         public static final JSONObject SET_CUSTOM_USER_ATTRIBUTES = new JSONObject() {{
             try {
                 put("custom_string", null);
@@ -668,16 +675,10 @@ public final class TestData {
             }
         }};
 
-        //Social
-        public static final String FACEBOOK_ID = "facebook-id";
-        public static final String TWITTER_HANDLE = "@twitter";
-        public static final String SCREEN_NAME = Values.USER_FIRST_NAME + " " + Values.USER_LAST_NAME;
-        public static final String USER_DESCRIPTION = "user desc";
-        public static final String PROFILE_IMAGE_URL = "http://images.com/1.gif";
-        public static final Integer TWITTER_ID = 123456;
-        public static final Integer TWEET_COUNT = 123;
-        public static final Integer FOLLOWERS_COUNT = 12;
-        public static final Integer FRIENDSCOUNT = 13;
+        public static final double LATITUDE = 0.0;
+        public static final double LONGITUDE = 1.1;
+        public static final double ALTITUDE = 2.2;
+        public static final double ACCURACY = 3.3;
     }
 
     public static final class Methods {
@@ -689,6 +690,7 @@ public final class TestData {
         public static final String LOG_CUSTOM_EVENT = "logCustomEvent";
         public static final String WIPE_DATA = "wipeData";
         public static final String ENABLE_SDK = "enableSdk";
+        public static final String DISABLE_SDK = "disableSdk";
         public static final String SET_USER_ALIAS = "setUserAlias";
         public static final String SET_USER_ID = "setUserId";
         public static final String SET_FIRST_NAME = "setUserFirstName";
@@ -697,8 +699,9 @@ public final class TestData {
         public static final String SET_LANGUAGE = "setUserLanguage";
         public static final String SET_GENDER = "setUserGender";
         public static final String SET_HOME_CITY = "setUserHomeCity";
-        public static final String SET_FACEBOOK_DATA = "setFacebookData";
-        public static final String SET_TWITTER_DATA = "setTwitterData";
+        public static final String SET_COUNTRY = "setUserCountry";
+        public static final String SET_PHONE = "setUserPhone";
+        public static final String SET_DATE_OF_BIRTH = "setUserDateOfBirth";
         public static final String SET_USER_CUSTOM_ATTRIBUTE = "setUserCustomAttribute";
         public static final String SET_USER_CUSTOM_ATTRIBUTES = "setUserCustomAttributes";
         public static final String INCREMENT_USER_CUSTOM_ATTRIBUTE = "incrementUserCustomAttribute";
@@ -712,8 +715,10 @@ public final class TestData {
         public static final String REMOVE_USER_CUSTOM_ATTRIBUTE_ARRAY = "removeFromUserCustomAttributeArray";
         public static final String REMOVE_USER_CUSTOM_ATTRIBUTES_ARRAY = "removeFromUserCustomAttributeArrays";
         public static final String REQUEST_FLUSH = "requestFlush";
-        public static final String REGISTER_PUSH = "registerToken";
         public static final String ADD_TO_SUBSCRIPTION = "addToSubscriptionGroup";
         public static final String REMOVE_FROM_SUBSCRIPTION = "removeFromSubscriptionGroup";
+        public static final String SET_LAST_KNOWN_LOCATION = "setLastKnownLocation";
+        public static final String SET_SDK_AUTH_SIGNATURE = "setSdkAuthSignature";
+        public static final String SET_AD_TRACKING_ENABLED = "setAdTrackingEnabled";
     }
 }

--- a/braze/src/androidTest/java/com/tealium/remotecommands/braze/TestUtils.java
+++ b/braze/src/androidTest/java/com/tealium/remotecommands/braze/TestUtils.java
@@ -26,7 +26,7 @@ public class TestUtils {
 
     public static boolean assertContainsAll(Collection<String> actual, Collection<String> expected) {
         boolean result = actual.containsAll(expected);
-        Assert.assertTrue("assertContainsAll: Not all expected methods were found.", result);
+        Assert.assertTrue("assertContainsAll: Not all expected methods were found. Actual:" + new JSONArray(actual) + " ->\n Expected: " + new JSONArray(expected), result);
         return result;
     }
 

--- a/braze/src/main/java/com/tealium/remotecommands/braze/BrazeCommand.java
+++ b/braze/src/main/java/com/tealium/remotecommands/braze/BrazeCommand.java
@@ -1,6 +1,7 @@
 package com.tealium.remotecommands.braze;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.tealium.remotecommands.braze.BrazeRemoteCommand.ConfigOverrider;
 
@@ -52,11 +53,16 @@ interface BrazeCommand {
     void initialize(String apiKey, JSONObject launchOptions, List<ConfigOverrider> overrides);
 
     /**
-     * Sets whether or not the Braze SDK is enabled or not.
+     * Sets the Braze SDK to enabled.
      *
-     * @param enabled - a value of false will disable the SDK, a value of true will enable it.
      */
-    void enableSdk(Boolean enabled);
+    void enableSdk();
+
+    /**
+     * Sets the Braze SDK to disabled.
+     *
+     */
+    void disableSdk();
 
     /**
      * Executes Braze's wipeData function to clear any user data stored on the device.
@@ -67,8 +73,17 @@ interface BrazeCommand {
      * Calls the changeUser method to switch which Braze User any subsequent events are related to.
      *
      * @param userId
+     * @param sdkAuthSignature
      */
-    void setUserId(String userId);
+    void setUserId(String userId, @Nullable String sdkAuthSignature);
+
+    /**
+     * Sets the Google ADID and sets whether or not to limit tracking
+     *
+     * @param googleAdid
+     * @param limitAdTracking
+     */
+    void setAdTrackingEnabled(String googleAdid, boolean limitAdTracking);
 
     /**
      * Registers an Alias and Alias Label for the current user. Neither parameter should be blank
@@ -133,6 +148,27 @@ interface BrazeCommand {
     void setUserHomeCity(String city);
 
     /**
+     * Sets the Country attribute for the current user in Braze.
+     *
+     * @param country
+     */
+    void setUserCountry(String country);
+
+    /**
+     * Sets the Phone attribute for the current user in Braze.
+     *
+     * @param phone
+     */
+    void setUserPhone(String phone);
+
+    /**
+     * Sets the Date of Birth for the current user in Braze.
+     *
+     * @param dob
+     */
+    void setUserDateOfBirth(String dob);
+
+    /**
      * Sets the Push Notification Subscription Type for the current user in Braze.
      * Uses Braze's helper method to convert from String to Enum:
      * NotificationSubscriptionType.valueOf(String notificationType)
@@ -149,52 +185,6 @@ interface BrazeCommand {
      * @param notificationType
      */
     void setEmailSubscriptionType(String notificationType);
-
-    /**
-     * Sets the Facebook Account Data for this current user in Braze
-     *
-     * @param facebookId
-     * @param firstName
-     * @param lastName
-     * @param email
-     * @param bio
-     * @param cityName
-     * @param gender
-     * @param numberOfFriends
-     * @param listOfLikes
-     * @param birthday
-     */
-    void setFacebookData(String facebookId,
-                         String firstName,
-                         String lastName,
-                         String email,
-                         String bio,
-                         String cityName,
-                         String gender,
-                         Integer numberOfFriends,
-                         JSONArray listOfLikes,
-                         String birthday);
-
-    /**
-     * Sets the Twitter Account Data for this current user in Braze
-     *
-     * @param twitterUserId
-     * @param twitterHandle
-     * @param name
-     * @param description
-     * @param followerCount
-     * @param followingCount
-     * @param tweetCount
-     * @param profileImageUrl
-     */
-    void setTwitterData(Integer twitterUserId,
-                        String twitterHandle,
-                        String name,
-                        String description,
-                        Integer followerCount,
-                        Integer followingCount,
-                        Integer tweetCount,
-                        String profileImageUrl);
 
     /**
      * Sets a Custom String Attribute for the current user in Braze
@@ -443,13 +433,6 @@ interface BrazeCommand {
     void requestFlush();
 
     /**
-     * Registers for push message using the Token provided - for manual registration.
-     *
-     * @param token
-     */
-    void registerToken(String token);
-
-    /**
      * Adds the current BrazeUser to a subscription group
      *
      * @param groupId
@@ -462,4 +445,21 @@ interface BrazeCommand {
      * @param groupId
      */
     void removeFromSubscriptionGroup(String groupId);
+
+    /**
+     * Sets the SDK Auth Signature
+     *
+     * @param signature
+     */
+    void setSdkAuthSignature(String signature);
+
+    /**
+     * Sets the last known location of the BrazeUser
+     *
+     * @param latitude
+     * @param longitude
+     * @param altitude
+     * @param accuracy
+     */
+    void setLastKnownLocation(@NonNull Double latitude, @NonNull  Double longitude, @Nullable Double altitude, @Nullable  Double accuracy);
 }

--- a/braze/src/main/java/com/tealium/remotecommands/braze/BrazeConstants.java
+++ b/braze/src/main/java/com/tealium/remotecommands/braze/BrazeConstants.java
@@ -16,9 +16,9 @@ public final class BrazeConstants {
         public static final String COMMAND_KEY = "command_name";
 
         public static final String INITIALIZE = "initialize";
-        public static final String ENABLE_SDK = "enable_sdk";
-        public static final String WIPE_DATA = "wipe_data";
-        public static final String REGISTER_TOKEN = "registertoken";
+        public static final String ENABLE_SDK = "enablesdk";
+        public static final String DISABLE_SDK = "disablesdk";
+        public static final String WIPE_DATA = "wipedata";
         public static final String USER_IDENTIFIER = "useridentifier";
         public static final String USER_ALIAS = "useralias";
         public static final String USER_ATTRIBUTE = "userattribute";
@@ -32,11 +32,12 @@ public final class BrazeConstants {
         public static final String PUSH_NOTIFICATION = "pushnotification";
         public static final String LOG_CUSTOM_EVENT = "logcustomevent";
         public static final String LOG_PURCHASE_EVENT = "logpurchase";
-        public static final String FACEBOOK_USER = "facebookuser";
-        public static final String TWITTER_USER = "twitteruser";
         public static final String FLUSH = "flush";
         public static final String ADD_TO_SUBSCRIPTION_GROUP = "addtosubscriptiongroup";
         public static final String REMOVE_FROM_SUBSCRIPTION_GROUP = "removefromsubscriptiongroup";
+        public static final String SET_SDK_AUTH_SIGNATURE = "setsdkauthsignature";
+        public static final String SET_LAST_KNOWN_LOCATION = "setlastknownlocation";
+        public static final String SET_AD_TRACKING_ENABLED = "setadtrackingenabled";
     }
 
     public static final class Config {
@@ -44,7 +45,6 @@ public final class BrazeConstants {
         }
 
         public static final String API_KEY = "api_key";
-        public static final String ENABLE_SDK = "enable_sdk";
         public static final String FIREBASE_ENABLED = "firebase_enabled";
         public static final String FIREBASE_SENDER_ID = "firebase_sender_id";
         public static final String SESSION_TIMEOUT = "session_timeout";
@@ -56,8 +56,6 @@ public final class BrazeConstants {
         public static final String DISABLE_LOCATION = "disable_location";
         public static final String ENABLE_NEWS_FEED_INDICATOR = "enable_news_feed_indicator";
         public static final String DEFAULT_NOTIFICATION_COLOR = "default_notification_color";
-        @Deprecated
-        public static final String LOCALE_MAPPING = "locale_mapping";
         public static final String BAD_NETWORK_INTERVAL = "bad_network_interval";
         public static final String GOOD_NETWORK_INTERVAL = "good_network_interval";
         public static final String GREAT_NETWORK_INTERVAL = "great_network_interval";
@@ -69,6 +67,7 @@ public final class BrazeConstants {
     }
 
     public static final class User {
+
         private User() {
         }
 
@@ -80,6 +79,8 @@ public final class BrazeConstants {
         public static final String EMAIL = "email";
         public static final String HOME_CITY = "home_city";
         public static final String DATE_OF_BIRTH = "date_of_birth";
+        public static final String COUNTRY = "country";
+        public static final String PHONE = "phone";
         public static final String ALIAS = "user_alias";
         public static final String ALIAS_LABEL = "user_alias_label";
         public static final String SET_CUSTOM_ATTRIBUTE = "set_custom_attribute";
@@ -88,20 +89,12 @@ public final class BrazeConstants {
         public static final String SET_CUSTOM_ARRAY_ATTRIBUTE = "set_custom_array_attribute";
         public static final String APPEND_CUSTOM_ARRAY_ATTRIBUTE = "append_custom_array_attribute";
         public static final String REMOVE_CUSTOM_ARRAY_ATTRIBUTE = "remove_custom_array_attribute";
-        public static final String FACEBOOK_ID = "facebook_id";
-        public static final String FRIENDS_COUNT = "friends_count";
-        public static final String LIKES = "likes";
-        public static final String DESCRIPTION = "description";
-        public static final String TWITTER_ID = "twitter_id";
-        public static final String TWITTER_NAME = "twitter_name";
-        public static final String PROFILE_IMAGE_URL = "profile_image_url";
-        public static final String SCREEN_NAME = "screen_name";
-        public static final String FOLLOWERS_COUNT = "followers_count";
-        public static final String STATUSES_COUNT = "statuses_count";
         public static final String EMAIL_NOTIFICATION = "email_notification";
         public static final String PUSH_NOTIFICATION = "push_notification";
-        public static final String PUSH_TOKEN = "push_token";
         public static final String SUBSCRIPTION_GROUP_ID = "subscription_group_id";
+        public static final String GOOGLE_ADID = "google_adid";
+        public static final String AD_TRACKING_ENABLED = "ad_tracking_enabled";
+        public static final String SDK_AUTH_SIGNATURE = "sdk_auth_signature";
     }
 
     public static final class Event {
@@ -125,4 +118,13 @@ public final class BrazeConstants {
         public static final String PURCHASE_PROPERTIES_SHORTHAND = "purchase";
     }
 
+    public static final class Location {
+        private Location() {
+        }
+
+        public static final String LOCATION_LATITUDE = "location_latitude";
+        public static final String LOCATION_LONGITUDE = "location_longitude";
+        public static final String LOCATION_ALTITUDE = "location_altitude";
+        public static final String LOCATION_ACCURACY = "location_accuracy";
+    }
 }

--- a/braze/src/main/java/com/tealium/remotecommands/braze/BrazeRemoteCommand.java
+++ b/braze/src/main/java/com/tealium/remotecommands/braze/BrazeRemoteCommand.java
@@ -20,6 +20,7 @@ import static com.tealium.remotecommands.braze.BrazeConstants.Config;
 import static com.tealium.remotecommands.braze.BrazeConstants.User;
 import static com.tealium.remotecommands.braze.BrazeConstants.Event;
 import static com.tealium.remotecommands.braze.BrazeConstants.Purchase;
+import static com.tealium.remotecommands.braze.BrazeConstants.Location;
 
 /**
  * Created by jameskeith on 23/10/2018.
@@ -151,20 +152,6 @@ public class BrazeRemoteCommand extends RemoteCommand {
      * "remove_custom_array_attribute : {
      * "attr_array_id_1" : "string_value_to_remove"
      * },
-     * "facebook_id" : "<string>",
-     * "friends_count" : <integer>,
-     * "likes" : [
-     * "likes"
-     * ],
-     * <p>
-     * // Social
-     * "description" : "<string>",
-     * "twitter_id" : <integer>,
-     * "twitter_name" : "<string>",
-     * "profile_image_url" : "<string>",
-     * "screen_name" : "<string>",
-     * "followers_count" : <integer>,
-     * "statuses_count" : <integer>,
      * <p>
      * // Notifications
      * "email_notification" : "<string>", // "unsubscribed", "subscribed", "opted_in"
@@ -233,18 +220,18 @@ public class BrazeRemoteCommand extends RemoteCommand {
                         );
                         break;
                     case Commands.ENABLE_SDK:
-                        if (BrazeUtils.keyHasValue(payload, Config.ENABLE_SDK)) {
-                            mBraze.enableSdk(
-                                    payload.optBoolean(Config.ENABLE_SDK)
-                            );
-                        }
+                        mBraze.enableSdk();
+                        break;
+                    case Commands.DISABLE_SDK:
+                        mBraze.disableSdk();
                         break;
                     case Commands.WIPE_DATA:
                         mBraze.wipeData();
                         break;
                     case Commands.USER_IDENTIFIER:
                         mBraze.setUserId(
-                                payload.optString(User.USER_ID)
+                                payload.optString(User.USER_ID),
+                                payload.optString(User.SDK_AUTH_SIGNATURE, null)
                         );
                         break;
                     case Commands.USER_ALIAS:
@@ -272,7 +259,15 @@ public class BrazeRemoteCommand extends RemoteCommand {
                         mBraze.setUserHomeCity(
                                 payload.optString(User.HOME_CITY)
                         );
-
+                        mBraze.setUserCountry(
+                                payload.optString(User.COUNTRY)
+                        );
+                        mBraze.setUserPhone(
+                                payload.optString(User.PHONE)
+                        );
+                        mBraze.setUserDateOfBirth(
+                                payload.optString(User.DATE_OF_BIRTH)
+                        );
                         break;
                     case Commands.SET_CUSTOM_ATTRIBUTE:
                         mBraze.setUserCustomAttributes(
@@ -338,37 +333,11 @@ public class BrazeRemoteCommand extends RemoteCommand {
                             mBraze.logPurchase(
                                     payload.optString(Purchase.PRODUCT_ID),
                                     payload.optString(Purchase.PRODUCT_CURRENCY),
-                                    new BigDecimal(payload.optDouble(Purchase.PRODUCT_PRICE, 0d)),
+                                    BigDecimal.valueOf(payload.optDouble(Purchase.PRODUCT_PRICE, 0d)),
                                     payload.optInt(Purchase.PRODUCT_QTY),
                                     purchaseProps
                             );
                         }
-                        break;
-                    case Commands.FACEBOOK_USER:
-                        mBraze.setFacebookData(
-                                payload.optString(User.FACEBOOK_ID, null),
-                                payload.optString(User.FIRST_NAME, null),
-                                payload.optString(User.LAST_NAME, null),
-                                payload.optString(User.EMAIL, null),
-                                payload.optString(User.DESCRIPTION, null),
-                                payload.optString(User.HOME_CITY, null),
-                                payload.optString(User.GENDER, null),
-                                payload.optInt(User.FRIENDS_COUNT, -1),
-                                payload.optJSONArray(User.LIKES),
-                                payload.optString(User.DATE_OF_BIRTH)
-                        );
-                        break;
-                    case Commands.TWITTER_USER:
-                        mBraze.setTwitterData(
-                                payload.optInt(User.TWITTER_ID, -1),
-                                payload.optString(User.TWITTER_NAME, null),
-                                payload.optString(User.SCREEN_NAME, null),
-                                payload.optString(User.DESCRIPTION, null),
-                                payload.optInt(User.FOLLOWERS_COUNT, -1),
-                                payload.optInt(User.FRIENDS_COUNT, -1),
-                                payload.optInt(User.STATUSES_COUNT, -1),
-                                payload.optString(User.PROFILE_IMAGE_URL, null)
-                        );
                         break;
                     case Commands.EMAIL_NOTIFICATION:
                         mBraze.setEmailSubscriptionType(
@@ -383,11 +352,6 @@ public class BrazeRemoteCommand extends RemoteCommand {
                     case Commands.FLUSH:
                         mBraze.requestFlush();
                         break;
-                    case Commands.REGISTER_TOKEN:
-                        mBraze.registerToken(
-                                payload.optString(User.PUSH_TOKEN, null)
-                        );
-                        break;
                     case Commands.ADD_TO_SUBSCRIPTION_GROUP:
                         mBraze.addToSubscriptionGroup(
                                 payload.optString(User.SUBSCRIPTION_GROUP_ID, null)
@@ -397,6 +361,30 @@ public class BrazeRemoteCommand extends RemoteCommand {
                         mBraze.removeFromSubscriptionGroup(
                                 payload.optString(User.SUBSCRIPTION_GROUP_ID, null)
                         );
+                        break;
+                    case Commands.SET_SDK_AUTH_SIGNATURE:
+                        mBraze.setSdkAuthSignature(
+                                payload.optString(User.SDK_AUTH_SIGNATURE, null)
+                        );
+                        break;
+                    case Commands.SET_LAST_KNOWN_LOCATION:
+                        double latitude = payload.getDouble(Location.LOCATION_LATITUDE);
+                        double longitude = payload.getDouble(Location.LOCATION_LONGITUDE);
+                        double altitude = payload.optDouble(Location.LOCATION_ALTITUDE);
+                        double accuracy = payload.optDouble(Location.LOCATION_ACCURACY);
+
+                        mBraze.setLastKnownLocation(
+                                latitude,
+                                longitude,
+                                Double.isNaN(altitude) ? null : altitude,
+                                Double.isNaN(accuracy) ? null : accuracy
+                        );
+                        break;
+                    case Commands.SET_AD_TRACKING_ENABLED:
+                        String googleAdid = payload.getString(User.GOOGLE_ADID);
+                        boolean adTrackingEnabled = payload.getBoolean(User.AD_TRACKING_ENABLED);
+
+                        mBraze.setAdTrackingEnabled(googleAdid, !adTrackingEnabled);
                         break;
                 }
             } catch (Exception ex) {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,8 @@
 
 buildscript {
     ext.kotlin_version = '1.6.21'
-    ext.tealium_braze_version = '2.0.0'
+    ext.tealium_braze_version = '2.1.0'
+    ext.braze_version = '[18.0,23.0)'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
 - Braze dependency updates - support for v18 -> v22
 - Support for additional commands:
   - `disablesdk` - requires no params
   - `setsdkauthsignature` - required `sdk_auth_signature` (String)
   - `setlastknownlocation` - required `location_latitude`, `location_longitude`; optional `location_accuracy`, `location_altitude`  
   - `setadtrackingenabled`  - required `google_adid`; optional: `
 - Support for some missing user attributes: `phone`, `country` and `date of birth`
 - Changed parameter requirements
   - `enablesdk` - no longer takes a boolean, should use `disablesdk` command instead
   - `useridentifier` - now accepts an optional `sdk_auth_signature` param along with the required `user_id`